### PR TITLE
Add GH actions example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: Build
+
+on:
+  workflow_dispatch:
+  push:
+
+env:
+    DOTNET_VERSION: 8.0.x
+
+jobs:
+
+  build-and-publish:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest, macos-14]
+        include:
+          - os: ubuntu-latest
+            runtime-identifier: linux-x64
+          - os: windows-latest
+            runtime-identifier: win-x64
+          - os: macOS-latest
+            runtime-identifier: osx-x64
+          - os: macos-14
+            runtime-identifier: osx-arm64
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: Nuget cache
+      uses: actions/cache@v4
+      with:
+        path:
+          ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
+    - name: Build
+      run: dotnet build -c Release
+
+    - name: Publish Engine
+      run: dotnet publish Leorik.Engine/Leorik.Engine.csproj -c Release --runtime ${{ matrix.runtime-identifier }} --self-contained /p:PublishSingleFile=true /p:PublishTrimmed=true -o artifacts/${{ matrix.runtime-identifier }}
+
+    - name: Upload Leorik-${{ github.run_number }}-${{ matrix.runtime-identifier }} artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: Leorik-${{ github.run_number }}-${{ matrix.runtime-identifier }}
+        path: |
+          artifacts/${{ matrix.runtime-identifier }}/
+          !artifacts/**/*.pdb
+        if-no-files-found: error


### PR DESCRIPTION
Add example workflow file with one job:

- Builds the solution
- Publishes the engine as self-contained, trimmed, single-file executable
- Uploads the resulting artifact

And it does that for each environment (`[ubuntu-latest, windows-latest, macOS-latest, macos-14]`)
You can see the result (running in my fork) [here](https://github.com/eduherminio/Leorik/actions/runs/7808003942). At the bottom you get the artifacts generated by it.

If you implement a command that does some search and exists without human intervention, you could add it that after the `publish` and double check that it executes correctly in that runner.

Feel free to have a look at [my own ones](https://github.com/lynx-chess/Lynx/tree/main/.github/workflows), especially CI and release ones could be useful.